### PR TITLE
Fix invisible blocking div

### DIFF
--- a/packages/forms/resources/css/components/file-upload.css
+++ b/packages/forms/resources/css/components/file-upload.css
@@ -41,6 +41,16 @@
         @apply rounded-full;
     }
 
+    & .filepond--root[data-style-panel-layout~='compact'],
+    & .filepond--root[data-style-panel-layout~='integrated'] {
+        & .filepond--list-scroller {
+            overflow: unset;
+            height: unset;
+            margin-top: 0;
+            margin-bottom: 0;
+        }
+    }
+
     & .filepond--panel-root {
         @apply bg-transparent;
     }


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description

Fixes issue: 

Overwrite the css classes because the filepond project seems to be not updated anymore.

Tested it for SpatieMediaLibraryFileUpload and FileUpload. With and without multiple().

## Visual changes
Before
![Screenshot 2025-07-06 at 12 43 16](https://github.com/user-attachments/assets/93fcdf0b-a43b-4360-a0d8-fb0a278ec82c)

After
![Screenshot 2025-07-09 at 22 55 05](https://github.com/user-attachments/assets/a33a3496-900f-488a-baef-fa4bfcb953c0)

Working like expected
https://github.com/user-attachments/assets/660ab34d-f442-4ad8-b569-259c06409fcc

<!-- Add screenshots/recordings of before and after. -->

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
